### PR TITLE
Convert fields inside test macro to upper case

### DIFF
--- a/macros/test_not_null.sql
+++ b/macros/test_not_null.sql
@@ -12,16 +12,24 @@ where:          Argument for providing additional filtering conditions in WHERE 
 
 {#- Prepare variables -#}
 
+{#- Upper case for all input parameters -#}
+
+{%- set column_name = column_name.upper() -%}
+{%- set key_columns_upper = [] -%}
+{%- for key_col in key_columns -%}
+    {%- do key_columns_upper.append(key_col.upper()) -%}
+{%- endfor -%}
+
 {#- Columns to generate error id: use key_columns list or all columns of the model -#}
 {%- set model_columns = adapter.get_columns_in_relation(model) -%}
 {%- set selected_columns = [] -%}
-{%- if key_columns|length != 0 -%}
-    {%- for column in model_columns if column['name'] in key_columns -%}
-        {%- do selected_columns.append(column['name']) -%}
+{%- if key_columns_upper|length != 0 -%}
+    {%- for column in model_columns if column['name'].upper() in key_columns_upper -%}
+        {%- do selected_columns.append(column['name'].upper()) -%}
     {%- endfor -%}
 {%- else -%}
-    {%- for column in model_columns if column['name'] != column_name -%}
-        {%- do selected_columns.append(column['name']) -%}
+    {%- for column in model_columns if column['name'].upper() != column_name -%}
+        {%- do selected_columns.append(column['name'].upper()) -%}
     {%- endfor -%}
 {%- endif -%}
 


### PR DESCRIPTION
When `dbt test` is executed with `--store-failures` flag, dbt puts SQL code of the test inside **Create or Replace As** statement to save errors into database table. To prevent database error, field names of tested model and test input parameters are converted into same case (upper case), so that same field aliased with different casing would not be present in the final SELECT statement.